### PR TITLE
fix: 修复 v28 API 400 错误及编辑器空白问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -539,12 +539,12 @@ const containerStyle = computed(() => {
   }
 
   // 根据不同视图设置不同的高度
-  if (currentView.value === 'list') {
+  // 编辑器和列表使用相同高度，避免切换时出现空白
+  if (currentView.value === 'list' || currentView.value === 'editor') {
     baseStyle.height = Math.min(settings.value.listMaxHeight, MAX_POPUP_HEIGHT) + 'px'
   } else if (showSettings.value) {
     baseStyle.height = Math.min(settings.value.settingHeight, MAX_POPUP_HEIGHT) + 'px'
   } else {
-    // 编辑器视图使用设置中的高度作为最小值
     baseStyle.minHeight = Math.min(settings.value.height, MAX_POPUP_HEIGHT) + 'px'
     baseStyle.height = 'auto'
   }
@@ -1575,17 +1575,20 @@ const decrementListMaxHeight = () => {
 
 // 监听页面尺寸变化
 watch([
-  () => settings.value.width, 
+  () => settings.value.width,
   () => settings.value.height,
-  () => settings.value.listMaxHeight, 
+  () => settings.value.listMaxHeight,
   () => settings.value.settingHeight,
   () => currentView.value,
   () => showSettings.value,
   () => content.value
 ], () => {
   nextTick(() => {
+    // 使用 double rAF 确保浏览器完成布局重计算后再读取 scrollHeight
     requestAnimationFrame(() => {
-      applyPopupDimensions()
+      requestAnimationFrame(() => {
+        applyPopupDimensions()
+      })
     })
   })
 }, { immediate: true })
@@ -1743,6 +1746,10 @@ const switchToEditor = () => {
   if (!ensureConfiguredOrOpenSettings()) return
   if(showSettings.value) showSettings.value = false;
   currentView.value = 'editor'
+  nextTick(() => {
+    updateEditorHeight()
+    focusEditor()
+  })
 }
 
 // 切换到列表视图
@@ -1777,6 +1784,10 @@ const handleEditMemo = (memo) => {
   visibility.value = memo.visibility
   showSettings.value = false
   currentView.value = 'editor'
+  nextTick(() => {
+    updateEditorHeight()
+    focusEditor()
+  })
 }
 
 const applyPopupDimensions = () => {
@@ -1793,14 +1804,10 @@ const applyPopupDimensions = () => {
 
   if (showSettings.value) {
     height = Math.min(settings.value.settingHeight, MAX_POPUP_HEIGHT)
-  } else if (currentView.value === 'list') {
+  } else if (currentView.value === 'list' || currentView.value === 'editor') {
     height = Math.min(settings.value.listMaxHeight, MAX_POPUP_HEIGHT)
   } else {
-    const root = document.querySelector('.memos-extension') as HTMLElement | null
-    const minHeight = Math.min(settings.value.height, MAX_POPUP_HEIGHT)
-    const contentHeight = root?.scrollHeight || minHeight
-
-    height = Math.min(Math.max(contentHeight, minHeight), MAX_POPUP_HEIGHT)
+    height = Math.min(settings.value.height, MAX_POPUP_HEIGHT)
   }
 
   document.documentElement.style.width = `${width}px`
@@ -1809,24 +1816,16 @@ const applyPopupDimensions = () => {
   document.body.style.height = `${height}px`
 }
 
-// 更新高度的函数
+// 更新编辑器容器高度，清除内联样式让 CSS flexbox 自动填充
 const updateEditorHeight = () => {
   if (currentView.value === 'editor' && !showSettings.value) {
     nextTick(() => {
       const editorContainer = document.querySelector('.editor-container') as HTMLElement | null
       if (editorContainer) {
-        // 使用设置中的高度作为最小高度，避免工具区换行时底部内容被截断
-        const height = isExtensionTarget
-          ? Math.min(settings.value.height, MAX_POPUP_HEIGHT)
-          : settings.value.height
-
-        // 更新所有相关元素的高度
-        requestAnimationFrame(() => {
-          editorContainer.style.minHeight = `${height}px`
-          editorContainer.style.height = 'auto'
-          applyPopupDimensions()
-        })
+        editorContainer.style.minHeight = ''
+        editorContainer.style.height = ''
       }
+      applyPopupDimensions()
     })
   }
 }
@@ -1944,6 +1943,7 @@ html, body {
   height: auto;
   min-height: 300px;
   overflow: visible;
+  flex: 1;
 }
 
 .editor-wrapper {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,10 +2,11 @@ import { v18Api } from './v18'
 import { v24Api } from './v24'
 import { v25Api } from './v25'
 import { v26Api } from './v26'
+import { v28Api } from './v28'
 
 /**
  * API 服务工厂
- * @param {string} version - API 版本 ('v18', 'v24' 或 'v25')
+ * @param {string} version - API 版本 ('v18', 'v24', 'v25', 'v26', 'v28')
  * @returns {Object} API 服务实例
  */
 export const createApiService = (version) => {
@@ -13,7 +14,8 @@ export const createApiService = (version) => {
     v18: v18Api,
     v24: v24Api,
     v25: v25Api,
-    v26: v26Api
+    v26: v26Api,
+    v28: v28Api
   }
 
   if (!apiMap[version]) {
@@ -32,7 +34,8 @@ export const getSupportedVersions = () => {
     v18: '0.18',
     v24: '0.24',
     v25: '0.25',
-    v26: '0.26'
+    v26: '0.26',
+    v28: '0.28'
   })
 }
 
@@ -46,7 +49,8 @@ export const getVersionDisplayName = (version) => {
     v18: '0.18',
     v24: '0.24',
     v25: '0.25',
-    v26: '0.26'
+    v26: '0.26',
+    v28: '0.28'
   }
   return versionMap[version] || version
 }

--- a/src/api/v28.js
+++ b/src/api/v28.js
@@ -1,0 +1,1118 @@
+/**
+ * Memos v0.28 API 服务
+ * 基于 Protocol Buffers (gRPC-Gateway) 的 RESTful API 接口
+ *
+ * v0.28 主要变更：
+ * - Auth: POST /api/v1/auth/signin + GET /api/v1/auth/me (替代 sessions 端点)
+ * - CreateMemo: body 包裹在 { "memo": {...} } 中
+ * - UpdateMemo: body 包裹在 { "memo": {...}, "update_mask": {...} } 中
+ * - CreateAttachment: body 包裹在 { "attachment": {...} } 中
+ */
+export const v28Api = {
+  /**
+   * 创建便签 - v0.28版本使用 gRPC-gateway 格式
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} content - 便签内容
+   * @param {string} visibility - 可见性设置 (PRIVATE/PROTECTED/PUBLIC)
+   * @param {Array} tags - 标签列表
+   * @param {boolean} pinned - 是否置顶
+   * @returns {Promise<Response>}
+   */
+  async createMemo(host, token, content, visibility = 'PUBLIC', tags = [], pinned = false) {
+    const response = await fetch(`${host}/api/v1/memos`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        memo: {
+          content,
+          visibility,
+          tags,
+          pinned
+        }
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error('创建便签失败')
+    }
+
+    return response
+  },
+
+  /**
+   * 获取便签列表
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {Object} options - 查询选项
+   * @param {number} options.pageSize - 每页数量 (默认50，最大1000)
+   * @param {string} options.pageToken - 分页令牌
+   * @param {string} options.filter - CEL过滤表达式
+   * @param {string} options.orderBy - 排序规则
+   * @param {string} options.state - 状态过滤 (NORMAL/ARCHIVED)
+   * @param {boolean} options.showDeleted - 是否显示已删除
+   * @returns {Promise<Response>}
+   */
+  async listMemos(host, token, options = {}) {
+    const {
+      pageSize = 50,
+      pageToken,
+      filter,
+      orderBy = 'pinned desc, display_time desc',
+      state = 'NORMAL',
+      showDeleted = false
+    } = options
+
+    const url = new URL(`${host}/api/v1/memos`)
+    url.searchParams.append('page_size', pageSize)
+
+    if (pageToken) url.searchParams.append('page_token', pageToken)
+    if (filter) url.searchParams.append('filter', filter)
+    if (orderBy) url.searchParams.append('order_by', orderBy)
+    if (state) url.searchParams.append('state', state)
+    if (showDeleted) url.searchParams.append('show_deleted', showDeleted)
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取便签列表失败')
+    }
+
+    return response
+  },
+
+  /**
+   * 获取便签详情
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 便签名称 (格式: memos/{memo_id})
+   * @returns {Promise<Object>}
+   */
+  async getMemo(host, token, memoName) {
+    const response = await fetch(`${host}/api/v1/${memoName}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取便签失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 更新便签 - v0.28版本使用 gRPC-gateway 格式
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 便签名称 (格式: memos/{memo_id})
+   * @param {Object} memo - 需要更新的便签字段
+   * @param {Array<string>} updateMask - 要更新的字段列表
+   * @returns {Promise<Object>}
+   */
+  async updateMemo(host, token, memoName, memo, updateMask = []) {
+    const requestBody = {
+      memo: {
+        name: memoName,
+        ...memo
+      }
+    }
+
+    if (updateMask.length > 0) {
+      requestBody.update_mask = {
+        paths: updateMask
+      }
+    }
+
+    const response = await fetch(`${host}/api/v1/${memoName}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify(requestBody)
+    })
+
+    if (!response.ok) {
+      throw new Error('更新便签失败')
+    }
+
+    return response
+  },
+
+  /**
+   * 删除便签
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 便签名称 (格式: memos/{memo_id})
+   * @returns {Promise<void>}
+   */
+  async deleteMemo(host, token, memoName) {
+    const response = await fetch(`${host}/api/v1/${memoName}`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('删除便签失败')
+    }
+  },
+
+  /**
+   * 重命名便签标签
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 便签名称 (格式: memos/{memo_id} 或 memos/- 表示所有便签)
+   * @param {string} oldTag - 旧标签名
+   * @param {string} newTag - 新标签名
+   * @returns {Promise<Object>}
+   */
+  async renameMemoTag(host, token, memoName, oldTag, newTag) {
+    const response = await fetch(`${host}/api/v1/${memoName}/tags:rename`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        old_tag: oldTag,
+        new_tag: newTag
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error('重命名标签失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 删除便签标签
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 便签名称 (格式: memos/{memo_id} 或 memos/- 表示所有便签)
+   * @param {string} tag - 要删除的标签名
+   * @returns {Promise<void>}
+   */
+  async deleteMemoTag(host, token, memoName, tag) {
+    const response = await fetch(`${host}/api/v1/${memoName}/tags:delete`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        tag: tag
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error('删除标签失败')
+    }
+  },
+
+  /**
+   * 设置便签附件
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 便签名称 (格式: memos/{memo_id})
+   * @param {Array<string>} attachmentNames - 附件名称列表 (格式: attachments/{attachment_id})
+   * @returns {Promise<Object>}
+   */
+  async setMemoAttachments(host, token, memoName, attachmentNames) {
+    const response = await fetch(`${host}/api/v1/${memoName}/attachments`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        attachments: attachmentNames.map(name => ({ name }))
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error('设置便签附件失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 获取便签附件列表
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 便签名称 (格式: memos/{memo_id})
+   * @returns {Promise<Object>}
+   */
+  async listMemoAttachments(host, token, memoName) {
+    const response = await fetch(`${host}/api/v1/${memoName}/attachments`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取便签附件列表失败')
+    }
+
+    const data = await response.json()
+
+    // 为每个附件添加正确的下载 URL
+    if (data.attachments && Array.isArray(data.attachments)) {
+      data.attachments = data.attachments.map(attachment => {
+        // 从 attachment.name 中提取附件ID (去掉 "attachments/" 前缀)
+        const attachmentId = attachment.name.replace('attachments/', '')
+        return {
+          ...attachment,
+          url: `${host}/file/attachments/${attachmentId}/${attachment.filename}`,
+          thumbnailUrl: `${host}/file/attachments/${attachmentId}/${attachment.filename}?thumbnail=true`
+        }
+      })
+    }
+
+    return data
+  },
+
+  /**
+   * 创建附件 - v0.28版本使用 gRPC-gateway 格式
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {File} file - 要上传的文件
+   * @param {string} memoName - 关联的便签名称 (可选，格式: memos/{memo_id})
+   * @returns {Promise<Object>}
+   */
+  async createAttachment(host, token, file, memoName = null) {
+    // 将文件转换为 base64
+    const base64Content = await new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        // 移除 base64 URL 的前缀（如 "data:image/jpeg;base64,"）
+        const base64 = reader.result.split(',')[1]
+        resolve(base64)
+      }
+      reader.onerror = reject
+      reader.readAsDataURL(file)
+    })
+
+    // 构建 attachment 对象
+    const attachment = {
+      filename: file.name,
+      content: base64Content,
+      type: file.type
+    }
+
+    // 只有当memoName存在且格式正确时才添加memo字段
+    if (memoName && memoName.startsWith('memos/')) {
+      attachment.memo = memoName
+    }
+
+    const response = await fetch(`${host}/api/v1/attachments`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({ attachment })
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(`创建附件失败: ${errorData.message || response.statusText}`)
+    }
+
+    const data = await response.json()
+
+    // 添加便于使用的 URL 和 Markdown
+    // 从 data.name 中提取附件ID (去掉 "attachments/" 前缀)
+    const attachmentId = data.name.replace('attachments/', '')
+    const fileUrl = data.external_link || `${host}/file/attachments/${attachmentId}/${data.filename}`
+    let markdown = ''
+    if (file.type.startsWith('image/')) {
+      markdown = `![${file.name}](${fileUrl})`
+    } else {
+      markdown = `[${file.name}](${fileUrl})`
+    }
+
+    return {
+      ...data,
+      id: data.name, // 添加id字段用于兼容
+      url: fileUrl,
+      thumbnailUrl: `${host}/file/attachments/${attachmentId}/${data.filename}?thumbnail=true`,
+      markdown: markdown
+    }
+  },
+
+  /**
+   * 获取附件列表
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {Object} options - 查询选项
+   * @param {number} options.pageSize - 每页数量
+   * @param {string} options.pageToken - 分页令牌
+   * @param {string} options.filter - 过滤条件
+   * @param {string} options.orderBy - 排序规则
+   * @returns {Promise<Object>}
+   */
+  async listAttachments(host, token, options = {}) {
+    const { pageSize = 50, pageToken, filter, orderBy = 'create_time desc' } = options
+
+    const url = new URL(`${host}/api/v1/attachments`)
+    url.searchParams.append('page_size', pageSize)
+
+    if (pageToken) url.searchParams.append('page_token', pageToken)
+    if (filter) url.searchParams.append('filter', filter)
+    if (orderBy) url.searchParams.append('order_by', orderBy)
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取附件列表失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 删除附件
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} attachmentName - 附件名称 (格式: attachments/{attachment_id})
+   * @returns {Promise<void>}
+   */
+  async deleteAttachment(host, token, attachmentName) {
+    const response = await fetch(`${host}/api/v1/${attachmentName}`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('删除附件失败')
+    }
+  },
+
+  /**
+   * 设置关系
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} name - 备忘录名称
+   * @param {Array<Object>} relations - 关系列表
+   * @returns {Promise<Object>}
+   */
+  async setRelations(host, token, name, relations) {
+    const response = await fetch(`${host}/api/v1/${name}/relations`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        relations: relations.map(relation => ({
+          type: relation.type,
+          memo: { id: relation.memoId }
+        }))
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error('设置关系失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 列出关系
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} name - 备忘录名称
+   * @returns {Promise<Object>}
+   */
+  async listRelations(host, token, name) {
+    const response = await fetch(`${host}/api/v1/${name}/relations`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取关系列表失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 创建评论
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} name - 备忘录名称
+   * @param {string} content - 评论内容
+   * @returns {Promise<Object>}
+   */
+  async createComment(host, token, name, content) {
+    const response = await fetch(`${host}/api/v1/${name}/comments`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        comment: { content }
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error('创建评论失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 列出评论
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} name - 备忘录名称
+   * @returns {Promise<Object>}
+   */
+  async listComments(host, token, name) {
+    const response = await fetch(`${host}/api/v1/${name}/comments`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取评论列表失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 列出反应
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} name - 备忘录名称
+   * @returns {Promise<Object>}
+   */
+  async listReactions(host, token, name) {
+    const response = await fetch(`${host}/api/v1/${name}/reactions`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取反应列表失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 设置反应
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} name - 备忘录名称
+   * @param {string} type - 反应类型
+   * @returns {Promise<Object>}
+   */
+  async setReaction(host, token, name, type) {
+    const response = await fetch(`${host}/api/v1/${name}/reactions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        reaction: { type }
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error('设置反应失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 删除反应
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} id - 反应ID
+   * @returns {Promise<void>}
+   */
+  async deleteReaction(host, token, id) {
+    const response = await fetch(`${host}/api/v1/reactions/${id}`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('删除反应失败')
+    }
+  },
+
+  /**
+   * 获取标签列表
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @returns {Promise<Array>}
+   */
+  async getTags(host, token) {
+    try {
+      // 从缓存中获取用户信息
+      const cachedSettings = localStorage.getItem('memos-settings')
+      if (!cachedSettings) {
+        console.log('未找到缓存设置，尝试使用通用端点获取标签')
+        return await this.getTagsWithoutUserInfo(host, token)
+      }
+
+      const settings = JSON.parse(cachedSettings)
+      if (!settings.userInfo || !settings.userInfo.name) {
+        console.log('用户信息不完整，尝试使用通用端点获取标签')
+        return await this.getTagsWithoutUserInfo(host, token)
+      }
+
+      // 检查是否有缓存的标签
+      const cachedTags = localStorage.getItem('memos-tags')
+      if (cachedTags) {
+        return JSON.parse(cachedTags)
+      }
+
+      // 使用便签列表端点
+      const response = await this.listMemos(host, token, {
+        pageSize: 1000,
+        orderBy: 'create_time desc'
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+
+        // 从便签中提取所有标签并去重
+        const allTags = (data.memos || []).reduce((tags, memo) => {
+          if (memo.tags && Array.isArray(memo.tags)) {
+            return [...tags, ...memo.tags]
+          }
+          return tags
+        }, [])
+
+        // 去重并缓存
+        const uniqueTags = [...new Set(allTags)]
+        localStorage.setItem('memos-tags', JSON.stringify(uniqueTags))
+
+        return uniqueTags
+      } else {
+        throw new Error('获取便签列表失败')
+      }
+    } catch (error) {
+      console.error('获取标签失败:', error)
+      // 如果主方法失败，尝试备用方法
+      return await this.getTagsWithoutUserInfo(host, token)
+    }
+  },
+
+  /**
+   * 在没有用户信息时获取标签的备用方法
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @returns {Promise<Array>}
+   */
+  async getTagsWithoutUserInfo(host, token) {
+    try {
+      const endpoints = [
+        `${host}/api/v1/memos?page_size=100&order_by=create_time desc`,
+        `${host}/api/v1/users/-/memos?page_size=100`
+      ];
+
+      for (const endpoint of endpoints) {
+        try {
+          const response = await fetch(endpoint, {
+            headers: {
+              'Authorization': `Bearer ${token}`
+            }
+          });
+
+          if (response.ok) {
+            const data = await response.json();
+
+            // 从便签中提取所有标签并去重
+            const allTags = (data.memos || []).reduce((tags, memo) => {
+              if (memo.tags && Array.isArray(memo.tags)) {
+                return [...tags, ...memo.tags]
+              }
+              return tags
+            }, []);
+
+            const uniqueTags = [...new Set(allTags)];
+            return uniqueTags;
+          }
+        } catch (error) {
+          console.log(`端点 ${endpoint} 失败:`, error.message);
+          continue;
+        }
+      }
+
+      // 如果所有端点都失败，返回空数组
+      return [];
+    } catch (error) {
+      console.error('备用标签获取方法失败:', error);
+      return [];
+    }
+  },
+
+  /**
+   * 清除标签缓存
+   */
+  clearTagCache() {
+    localStorage.removeItem('memos-tags')
+  },
+
+  /**
+   * 上传附件 (兼容旧接口名称)
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {File} file - 要上传的文件
+   * @param {string} memoName - 关联的便签名称 (可选)
+   * @returns {Promise<Object>}
+   */
+  async uploadResource(host, token, file, memoName = null) {
+    return await this.createAttachment(host, token, file, memoName)
+  },
+
+  /**
+   * 测试连接 - v0.28版本使用 GET /api/v1/auth/me
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @returns {Promise<Object>}
+   */
+  async testConnection(host, token) {
+    // v0.28版本优先使用 auth/me 端点
+    const endpoints = [
+      { url: `${host}/api/v1/auth/me`, method: 'GET' },
+      { url: `${host}/api/v1/users/-`, method: 'GET' },
+      { url: `${host}/api/v1/me`, method: 'GET' },
+      { url: `${host}/api/v1/user/me`, method: 'GET' }
+    ];
+
+    let lastError = null;
+
+    for (const endpoint of endpoints) {
+      try {
+        const response = await fetch(endpoint.url, {
+          method: endpoint.method,
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+
+          // auth/me 返回 { user: {...} }
+          if (data.user) {
+            return {
+              ok: true,
+              data: {
+                name: data.user.name || data.user.username || `user_${data.user.id}`,
+                username: data.user.username,
+                email: data.user.email,
+                role: data.user.role || 'USER',
+                state: data.user.state || 'NORMAL',
+                id: data.user.id,
+                endpoint: endpoint.url
+              }
+            };
+          } else if (data.name || data.username || data.id) {
+            // 用户信息直接响应格式
+            return {
+              ok: true,
+              data: {
+                name: data.name || data.username || `user_${data.id}`,
+                username: data.username,
+                email: data.email,
+                role: data.role || 'USER',
+                state: data.state || 'NORMAL',
+                id: data.id,
+                endpoint: endpoint.url
+              }
+            };
+          }
+        }
+      } catch (error) {
+        lastError = error;
+        continue;
+      }
+    }
+
+    throw new Error(`所有认证端点都失败。最后错误: ${lastError?.message || '未知错误'}`);
+  },
+
+  /**
+   * 创建认证会话 (登录) - v0.28版本使用 POST /api/v1/auth/signin
+   * @param {string} host - Memos 主机地址
+   * @param {string} username - 用户名
+   * @param {string} password - 密码
+   * @returns {Promise<Object>}
+   */
+  async createSession(host, username, password) {
+    const response = await fetch(`${host}/api/v1/auth/signin`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        password_credentials: {
+          username,
+          password
+        }
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error('登录失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 删除当前会话 (登出) - v0.28版本使用 POST /api/v1/auth/signout
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @returns {Promise<void>}
+   */
+  async deleteSession(host, token) {
+    const response = await fetch(`${host}/api/v1/auth/signout`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error('登出失败')
+    }
+  },
+
+  /**
+   * 关联资源到备忘录
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} memoName - 备忘录名称
+   * @param {Array<Object>} resources - 资源列表
+   * @returns {Promise<Response>}
+   */
+  async associateResources(host, token, memoName, resources) {
+    const response = await fetch(`${host}/api/v1/${memoName}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify(resources)
+    })
+
+    if (!response.ok) {
+      throw new Error('关联资源失败')
+    }
+
+    return response
+  },
+
+  /**
+   * 获取备忘录列表 - 改进的查询和过滤
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {Object} options - 查询选项
+   * @param {number} options.offset - 偏移量
+   * @param {number} options.limit - 每页数量
+   * @param {string} options.content - 搜索内容
+   * @param {string} options.visibility - 可见性过滤
+   * @param {string} options.tag - 标签过滤
+   * @returns {Promise<Response>}
+   */
+  async getMemos(host, token, { offset = null, limit = 10, content, visibility, tag } = {}) {
+    const url = new URL(`${host}/api/v1/memos`)
+
+    // 构建过滤条件 - 一次性构建，避免重复 append/set
+    let filter = '';
+    if (content) {
+      const trimmedContent = content.trim();
+      if (trimmedContent) {
+        // 转义双引号防止 CEL 注入，统一使用单引号包裹避免嵌套双引号问题
+        const escapedContent = trimmedContent.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+        filter = `content.contains('${escapedContent}')`;
+      }
+    }
+
+    if (visibility && visibility !== 'all') {
+      const visibilityFilter = `visibility == '${visibility.toUpperCase()}'`
+      filter = filter ? `${filter} && ${visibilityFilter}` : visibilityFilter
+    }
+
+    // 分页参数
+    if (offset) {
+      url.searchParams.append('page_token', offset)
+    }
+
+    url.searchParams.append('page_size', limit)
+
+    // 一次性设置 filter
+    if (filter) {
+      url.searchParams.append('filter', filter)
+    }
+
+    // 标签过滤在客户端处理
+    if (tag) {
+      console.log('标签过滤将在客户端进行:', tag)
+    }
+
+    return await fetch(url.toString(), {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+  },
+
+  /**
+   * 获取用户列表
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {Object} options - 查询选项
+   * @param {number} options.pageSize - 每页数量
+   * @param {string} options.pageToken - 分页令牌
+   * @param {string} options.filter - 过滤条件
+   * @param {boolean} options.showDeleted - 是否显示已删除用户
+   * @returns {Promise<Object>}
+   */
+  async listUsers(host, token, options = {}) {
+    const { pageSize = 50, pageToken, filter, showDeleted = false } = options
+
+    const url = new URL(`${host}/api/v1/users`)
+    url.searchParams.append('page_size', pageSize)
+
+    if (pageToken) url.searchParams.append('page_token', pageToken)
+    if (filter) url.searchParams.append('filter', filter)
+    if (showDeleted) url.searchParams.append('show_deleted', showDeleted)
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取用户列表失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 获取用户信息
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} userIdOrUsername - 用户ID或用户名
+   * @returns {Promise<Object>}
+   */
+  async getUser(host, token, userIdOrUsername) {
+    const response = await fetch(`${host}/api/v1/users/${userIdOrUsername}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取用户信息失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 获取用户设置列表
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} userName - 用户名称 (格式: users/{user_id})
+   * @returns {Promise<Object>}
+   */
+  async listUserSettings(host, token, userName) {
+    const response = await fetch(`${host}/api/v1/${userName}/settings`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取用户设置列表失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 获取用户特定设置
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} userName - 用户名称 (格式: users/{user_id})
+   * @param {string} settingKey - 设置键 (GENERAL/SESSIONS/ACCESS_TOKENS/WEBHOOKS)
+   * @returns {Promise<Object>}
+   */
+  async getUserSetting(host, token, userName, settingKey) {
+    const response = await fetch(`${host}/api/v1/${userName}/settings/${settingKey}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取用户设置失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 更新用户设置
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} userName - 用户名称 (格式: users/{user_id})
+   * @param {string} settingKey - 设置键
+   * @param {Object} setting - 设置对象
+   * @param {Array<string>} updateMask - 要更新的字段列表
+   * @returns {Promise<Object>}
+   */
+  async updateUserSetting(host, token, userName, settingKey, setting, updateMask = []) {
+    const requestBody = {
+      setting: {
+        name: `${userName}/settings/${settingKey}`,
+        ...setting
+      }
+    }
+
+    if (updateMask.length > 0) {
+      requestBody.update_mask = {
+        paths: updateMask
+      }
+    }
+
+    const response = await fetch(`${host}/api/v1/${userName}/settings/${settingKey}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify(requestBody)
+    })
+
+    if (!response.ok) {
+      throw new Error('更新用户设置失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 获取工作空间概况
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @returns {Promise<Object>}
+   */
+  async getWorkspaceProfile(host, token) {
+    const response = await fetch(`${host}/api/v1/workspace/profile`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取工作空间概况失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 获取工作空间设置
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} settingKey - 设置键 (GENERAL/STORAGE/MEMO_RELATED)
+   * @returns {Promise<Object>}
+   */
+  async getWorkspaceSetting(host, token, settingKey) {
+    const response = await fetch(`${host}/api/v1/workspace/settings/${settingKey}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error('获取工作空间设置失败')
+    }
+
+    return response.json()
+  },
+
+  /**
+   * 更新工作空间设置
+   * @param {string} host - Memos 主机地址
+   * @param {string} token - 访问令牌
+   * @param {string} settingKey - 设置键
+   * @param {Object} setting - 设置对象
+   * @param {Array<string>} updateMask - 要更新的字段列表
+   * @returns {Promise<Object>}
+   */
+  async updateWorkspaceSetting(host, token, settingKey, setting, updateMask = []) {
+    const requestBody = {
+      setting: {
+        name: `workspace/settings/${settingKey}`,
+        ...setting
+      }
+    }
+
+    if (updateMask.length > 0) {
+      requestBody.update_mask = {
+        paths: updateMask
+      }
+    }
+
+    const response = await fetch(`${host}/api/v1/workspace/settings/${settingKey}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify(requestBody)
+    })
+
+    if (!response.ok) {
+      throw new Error('更新工作空间设置失败')
+    }
+
+    return response.json()
+  }
+}

--- a/src/views/MemosList.vue
+++ b/src/views/MemosList.vue
@@ -111,7 +111,7 @@
             </div>
             
             <!-- 资源列表展示 -->
-            <div v-if="(settings.apiVersion === 'v24' || settings.apiVersion === 'v25' || settings.apiVersion === 'v26') && memo.resources && memo.resources.length > 0" class="resources-container">
+            <div v-if="(settings.apiVersion === 'v24' || settings.apiVersion === 'v25' || settings.apiVersion === 'v26' || settings.apiVersion === 'v28' || settings.apiVersion === 'v28') && memo.resources && memo.resources.length > 0" class="resources-container">
               <div class="resources-list">
                 <!-- 图片资源 -->
                 <div v-for="resource in memo.resources.filter(r => r.type.startsWith('image/'))" 
@@ -269,24 +269,39 @@ const fetchMemos = async () => {
     const offset = 0 // 重置 offset
     page.value = 1 // 重置页码
     hasMore.value = true // 重置加载更多状态
-    
+
+    // 构建请求参数
+    const params = {
+      offset,
+      limit,
+      visibility: props.settings.visibilityFilter,
+      content: searchQuery.value,
+      tag: selectedTag.value
+    }
+
+    console.log('v28 fetchMemos 调试 - 请求参数:', {
+      apiVersion: props.settings.apiVersion,
+      host: props.settings.host,
+      token: props.settings.token ? '***' : 'empty',
+      params
+    })
+
     const response = await api.getMemos(
       props.settings.host,
       props.settings.token,
-      {
-        offset,
-        limit,
-        visibility: props.settings.visibilityFilter,
-        content: searchQuery.value,
-        tag: selectedTag.value
-      }
+      params
     )
 
+    console.log('v28 fetchMemos 调试 - 响应状态:', response.status, 'OK:', response.ok)
+
     if (!response.ok) {
-      throw new Error('获取备忘录失败')
+      const errorText = await response.text().catch(() => 'unknown error')
+      console.error('v28 fetchMemos 调试 - 错误响应:', errorText)
+      throw new Error(`获取备忘录失败：${response.status} ${response.statusText}`)
     }
 
     let data = await response.json()
+    console.log('v28 fetchMemos 调试 - 原始数据:', data)
     
     if (props.settings.apiVersion === 'v24') {
       nextPageToken.value = data.nextPageToken;
@@ -301,12 +316,12 @@ const fetchMemos = async () => {
           console.warn('获取资源失败:', memo.name, error)
         }
       }))
-    } else if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26') {
-      // v25/v26 版本数据处理
+    } else if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26' || props.settings.apiVersion === 'v28') {
+      // v25/v26/v28 版本数据处理
       nextPageToken.value = data.nextPageToken || data.next_page_token || ''
       data = data.memos || []
-      
-      // v25/v26 字段映射和处理
+
+      // v25/v26/v28 字段映射和处理
       for (const memo of data) {
         // 确保时间字段兼容性
         if (memo.createTime && !memo.createdTs) {
@@ -318,7 +333,7 @@ const fetchMemos = async () => {
         if (memo.updateTime && !memo.updatedTs) {
           memo.updatedTs = new Date(memo.updateTime).getTime()
         }
-        
+
         // 处理附件
         if (memo.attachments && memo.attachments.length > 0) {
           try {
@@ -336,8 +351,8 @@ const fetchMemos = async () => {
       }
     }
     
-    // 客户端标签过滤（v25/v26）
-    if ((props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26') && selectedTag.value) {
+    // 客户端标签过滤（v25/v26/v28）
+    if ((props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26' || props.settings.apiVersion === 'v28') && selectedTag.value) {
       data = data.filter(memo => {
         return memo.tags && memo.tags.includes(selectedTag.value)
       })
@@ -345,7 +360,7 @@ const fetchMemos = async () => {
     }
     
     // 检查是否还有更多数据
-    if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26') {
+    if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26' || props.settings.apiVersion === 'v28') {
       // v25/v26：如果返回的数据量等于 limit，假设还有更多数据
       if (data.length >= limit) {
         hasMore.value = true
@@ -536,12 +551,12 @@ const loadMore = async () => {
           console.warn('获取资源失败:', memo.name, error)
         }
       }))
-    } else if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26') {
-      // v25/v26 版本数据处理
+    } else if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26' || props.settings.apiVersion === 'v28') {
+      // v25/v26/v28 版本数据处理
       nextPageToken.value = data.nextPageToken || data.next_page_token || ''
       data = data.memos || []
-      
-      // v25/v26 字段映射和处理
+
+      // v25/v26/v28 字段映射和处理
       for (const memo of data) {
         // 确保时间字段兼容性
         if (memo.createTime && !memo.createdTs) {
@@ -553,7 +568,7 @@ const loadMore = async () => {
         if (memo.updateTime && !memo.updatedTs) {
           memo.updatedTs = new Date(memo.updateTime).getTime()
         }
-        
+
         // 处理附件
         if (memo.attachments && memo.attachments.length > 0) {
           try {
@@ -580,7 +595,7 @@ const loadMore = async () => {
     }
 
     // 根据版本和数据量判断是否还有更多数据
-    if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26') {
+    if (props.settings.apiVersion === 'v25' || props.settings.apiVersion === 'v26' || props.settings.apiVersion === 'v28') {
       // v25/v26：如果返回的数据量等于limit，假设还有更多数据
       if (data.length >= limit) {
         hasMore.value = true

--- a/src/views/setting.vue
+++ b/src/views/setting.vue
@@ -21,7 +21,8 @@
           { value: 'v18', label: '0.18' },
           { value: 'v24', label: '0.24' },
           { value: 'v25', label: '0.25' },
-          { value: 'v26', label: '0.26' }
+          { value: 'v26', label: '0.26' },
+          { value: 'v28', label: '0.28' }
         ]"
         :disabled="isLoading"
       />
@@ -418,7 +419,7 @@ const fetchTags = async () => {
         return acc
       }, {})
     } else {
-      // v24/v25/v26 返回字符串数组
+      // v24/v25/v26/v28 返回字符串数组
       tags.value = Array.isArray(data) ? data : []
       tagCounts.value = (Array.isArray(data) ? data : []).reduce((acc, tag) => {
         const tagName = typeof tag === 'string' ? tag : (tag.name || tag)


### PR DESCRIPTION
- 修复 Memos v0.28 获取备忘录时的 400 错误
  - 简化 filter 参数构建方式，使用单引号 CEL 语法
  - 移除不支持 order_by/state 参数
- 修复列表切换回编辑器的底部空白问题
  - 编辑器和列表视图使用相同固定高度（listMaxHeight）
  - 简化 updateEditorHeight，由 CSS flexbox 自动填充
- 新增 v28 API 支持
- 设置页新增 v0.28 版本选项